### PR TITLE
fix bugs for json path and local variable round_number

### DIFF
--- a/word2world/play_game.py
+++ b/word2world/play_game.py
@@ -35,12 +35,12 @@ if args.game_path:
         data = json.load(file)
 else:
     game = "example_1"
-    round_number = "round_0"
-    game_dir = f"word2world\examples"
+    game_dir = os.path.join(f"word2world", "examples")
 
     with open(f'{game_dir}/{game}.json', 'r') as file:
         data = json.load(file)
 
+round_number = "round_0"
 character_descriptions_dict = {}
 gen_story = data[round_number]["story"]
 grid_str = data[round_number]["world"]


### PR DESCRIPTION
1. On Linux machine, "\\" is illegal for path so I modified to use os.path.join to get the example json.
2. For `round_number`, it's declared as local variable so errors would be reported when `game_path` is specified. I modified to declare it outside the `if else`.